### PR TITLE
v2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Qubit is the fastest and most scalable personalization platform available today.
 
 # Release notes
 
+**March 2019 - Release v2.5**
+- Updated `q_experience`* and `q_goal_achieved`* views to provide latest _Experience Name_.
+- Updated `q_experience`* and `q_goal_achieved`* views to fix a rare issue where _Experience Status_ was calculated incorrectly.
+- Fixed column type bug that was preventing `q_goal_achieved.days_experience_live` from calculating.
+
 **December 2018 - Release v2.3**
 - Add site filter: enabling easy switching between separate projects
 - You a can now use a single date filter to easily filter all views in the Explore

--- a/q_experience.view.lkml
+++ b/q_experience.view.lkml
@@ -109,7 +109,7 @@ view: q_experience {
   }
 
   #Experience related dimensions
-  
+
   dimension: experience_id {
     type: string
     sql: CAST(${TABLE}.experienceId AS STRING) ;;
@@ -121,7 +121,8 @@ view: q_experience {
     type: string
     sql: ${TABLE}.experienceName ;;
     group_label: "Experience"
-    description: "The assigned name of experience. QP fields: experienceName"
+    description: "The assigned name of experience."
+    hidden: yes
   }
 
   dimension: iteration_id {

--- a/q_experience_meta_data.view.lkml
+++ b/q_experience_meta_data.view.lkml
@@ -1,55 +1,96 @@
 view: q_experience_meta_data {
   derived_table: {
     sql:
-    SELECT
-      CAST(experienceId AS STRING) experienceId,
-      DATE(MAX(experience_last_paused_at)) experience_last_paused_at,
-      DATE(MIN(experience_first_published_at)) experience_first_published_at
-    FROM (
-      SELECT
-        *,
-        MIN(iteration_published_at) OVER (PARTITION BY experienceId) AS experience_first_published_at,
-        CAST(DATE(iteration_paused_at) AS STRING) iteration_paused_at_date,
-        CAST(DATE(iteration_published_at) AS STRING) iteration_published_at_date,
-        UNIX_MILLIS(iteration_paused_at) AS iteration_paused_at_unix_ts,
-        MAX(iteration_paused_at) OVER (PARTITION BY experienceId) AS experience_last_paused_at
-      FROM (
+     WITH
+      iterations AS
+      (
         SELECT
-          COALESCE(iteration_published_at_first,iteration_started_at,iteration_created_at,iteration_upadted_at) AS iteration_published_at,
-          *
+          experienceId AS experienceId,
+          variationMasterId AS variationMasterId,
+          iterationId AS iterationId,
+          MAX(iterationName) AS iterationName,
+          MIN(iterationStartedAt) AS iterationStartedAt,
+          MIN(iterationPublishedAt) AS iterationPublishedAt,
+          MIN(iterationPausedAt) AS iterationPausedAt
+        FROM
+          `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.aux_experience_iteration_variation_v01`
+        WHERE
+          experienceId IS NOT NULL
+          AND iterationId IS NOT NULL
+          AND variationMasterId IS NOT NULL
+        GROUP BY
+          1,
+          2,
+          3 ),
+
+      iteration_metadata AS
+      (
+        SELECT
+          experienceId,
+          variationMasterId,
+          iterationId,
+          iterationName,
+          iterationStartedAt,
+          iterationPausedAt,
+          IF (iterationPublishedAt IS NULL,
+            TRUE,
+            FALSE) AS inDraft,
+          IF (iterationId = FIRST_VALUE(iterationId) OVER (PARTITION BY experienceId, variationMasterId ORDER BY iterationStartedAt DESC),
+            TRUE,
+            FALSE) AS isLatestIteration
+        FROM
+          iterations
+      ),
+
+      status AS
+      (
+        SELECT
+          *,
+          IF (isLatestIteration = TRUE
+            AND iterationPausedAt IS NULL
+            AND iterationStartedAt IS NOT NULL,
+            TRUE,
+            FALSE) AS isActive
+        FROM
+          iteration_metadata
+      ),
+
+      latestName AS (
+        SELECT
+          ROW.experienceId,
+          ROW.experienceName
         FROM (
           SELECT
-            experienceId AS experienceId,
-            variationMasterId AS variationMasterId,
-            iterationId AS iterationId,
-            MAX(experienceName) AS experienceName,
-            MAX(variationName) AS variationName,
-            MAX(iterationName) AS iterationName,
-            MIN(CASE
-                  WHEN iterationUpdatedAt > COALESCE(iterationStartedAt, TIMESTAMP_MILLIS(0)) AND iterationPausedAt IS NULL THEN iterationUpdatedAt
-                  WHEN iterationPausedAt > COALESCE(iterationStartedAt, TIMESTAMP_MILLIS(0))
-                AND iterationPausedAt > COALESCE(iterationPublishedAt, TIMESTAMP_MILLIS(0))
-                AND iterationPausedAt > COALESCE(iterationResumedAt, TIMESTAMP_MILLIS(0)) THEN iterationPausedAt
-                  ELSE TIMESTAMP('2030-01-01 00:00:00 UTC') END) AS iteration_paused_at,
-            MIN(iterationPublishedAt) AS iteration_published_at_first,
-            MIN(iterationStartedAt) AS iteration_started_at,
-            MIN(iterationCreatedAt) AS iteration_created_at,
-            MIN(iterationUpdatedAt) AS iteration_upadted_at
+            ARRAY_AGG(t
+            ORDER BY
+              meta_recordDate DESC
+            LIMIT
+              1)[
+          OFFSET
+            (0)] AS ROW
           FROM
-            `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.aux_experience_iteration_variation_v01`
+            `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.aux_experience_iteration_variation_v01` AS t
           GROUP BY
-            1,
-            2,
-            3) AS experience_metadata ) AS experience_metadata_1
-      WHERE
-        (experienceId IS NOT NULL
-          AND CAST(experienceId AS STRING) != 'undefined'
-          AND variationMasterId IS NOT NULL
-          AND CAST(variationMasterId AS STRING) != 'undefined'
-          AND iterationId IS NOT NULL
-          AND CAST(iterationId AS STRING) != 'undefined' ))
+            experienceId,
+            experienceName
+        )
+    )
+
+    SELECT
+      CAST(status.experienceId AS STRING) experienceId,
+      CAST(experienceName as STRING) experienceName,
+      DATE(MIN(iterationStartedAt)) experience_first_published_at,
+      DATE(MAX(iterationPausedAt)) experience_last_paused_at,
+      MAX(isActive) AS is_active
+
+    FROM
+      status
+
+    LEFT JOIN
+      latestName on (status.experienceId = latestName.experienceId)
+
     GROUP BY
-      1
+      1, 2
     ;;
     }
 
@@ -62,17 +103,19 @@ view: q_experience_meta_data {
     dimension: experience_name {
       type: string
       sql: ${TABLE}.experienceName ;;
-      hidden: yes
+      view_label: "Experiences"
+      group_label: "Experience"
+      label: "Experience Name"
+      description: "The name of experience in app.qubit.com."
     }
 
     dimension: current_experience_status {
       view_label: "Experiences"
       type: string
-      sql: IF(${TABLE}.experience_last_paused_at <= CURRENT_DATE() , "Paused" , "Active") ;;
+      sql: IF(${TABLE}.is_active = true , "Active" , "Paused") ;;
       label: "Current Experience Status "
-      description: "Status of the experience as of today"
+      description: "Status of the experience as of today."
       group_label: "Experience"
-
     }
 
     dimension: experience_first_published_at {
@@ -80,7 +123,7 @@ view: q_experience_meta_data {
       type: date
       sql: TIMESTAMP(${TABLE}.experience_first_published_at) ;;
       group_label: "Experience"
-      description: "Date the first iteration of experience was published"
+      description: "Date the experience was first published."
     }
 
     dimension: experience_last_paused_at {
@@ -88,6 +131,6 @@ view: q_experience_meta_data {
       type: date
       sql: TIMESTAMP(${TABLE}.experience_last_paused_at) ;;
       group_label: "Experience"
-      description: "Most recent date experience was paused"
+      description: "The recent date experience was paused."
     }
 }

--- a/q_goal_achieved.view.lkml
+++ b/q_goal_achieved.view.lkml
@@ -42,8 +42,8 @@ view: q_goal_achieved {
         experience_goal_achieved.experience_paused_within_15_days AS experience_paused_within_15_days
       FROM
         `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.livetap_goal_achieved`
-      LEFT JOIN 
-        UNNEST (experience_goal_achieved) as experience_goal_achieved 
+      LEFT JOIN
+        UNNEST (experience_goal_achieved) as experience_goal_achieved
       WHERE
         {% condition q_view_v01.time_data_points_date  %} property_event_ts {% endcondition %}
       ;;
@@ -89,6 +89,7 @@ view: q_goal_achieved {
     sql: ${TABLE}.experienceName ;;
     group_label: "Experience"
     description: "The name of experience which the goal refers to. QP fields: experienceName"
+    hidden:  yes
   }
 
   dimension: goal_id {
@@ -149,6 +150,7 @@ view: q_goal_achieved {
     group_label: "Experience"
     description: "Master variation ID of an experiment. The ID is assigned when a variation is launched and it is preserved throughout the experiment. QP fields: variationMasterId"
   }
+
   dimension: variation_name {
     type: string
     sql: ${TABLE}.variationName ;;
@@ -168,23 +170,23 @@ view: q_goal_achieved {
     group_label: "Experience"
     description: "Status of the experience at the time of pageview"
 
-}
+  }
 
-dimension: experience_paused_15_days_window {
-    type: yesno
-    sql: ${TABLE}.experience_paused_within_15_days = 1 ;;
-    label: "Experience Paused - 15-day window"
+  dimension: experience_paused_15_days_window {
+      type: yesno
+      sql: ${TABLE}.experience_paused_within_15_days = 1 ;;
+      label: "Experience Paused - 15-day window"
+      group_label: "Experience"
+      description: "True if view happened within 15 days of the date experience being paused "
+      hidden: yes
+  }
+
+  dimension: days_experience_live_on_visitors_view {
+    type: number
+    sql: ${TABLE}.days_experience_live ;;
     group_label: "Experience"
-    description: "True if view happened within 15 days of the date experience being paused "
-    hidden: yes
-}
-
-dimension: days_experience_live_on_visitors_view {
-  type: number
-  sql: ${TABLE}.days_experience_live ;;
-  group_label: "Experience"
-  description: "The number of days the experience had been live at the time of user's pageview"
-}
+    description: "The number of days the experience had been live at the time of user's pageview"
+  }
 
 
   dimension: iteration_published_at {
@@ -239,7 +241,7 @@ dimension: days_experience_live_on_visitors_view {
 
   measure: days_experience_live {
     type: number
-    sql:   COUNT(DISTINCT IF(${TABLE}.experience_status  = 'Live' AND ${TABLE}.meta_recordDate >= ${TABLE}.experience_first_published_at, ${TABLE}.meta_recordDate, NULL) ) ;;
+    sql:   COUNT(DISTINCT IF(${TABLE}.experience_status  = 'Live' AND ${TABLE}.meta_recordDate >= CAST(${TABLE}.experience_first_published_at as DATE), ${TABLE}.meta_recordDate, NULL) ) ;;
     group_label: "Experience"
     description: "The number of days the experience has been live as of today"
   }

--- a/q_goal_achieved_meta_data.view.lkml
+++ b/q_goal_achieved_meta_data.view.lkml
@@ -2,56 +2,99 @@ view: q_goal_achieved_meta_data {
   derived_table: {
 
     sql:
-    SELECT
-      CAST(experienceId AS STRING) experienceId,
-      DATE(MAX(experience_last_paused_at)) experience_last_paused_at,
-      DATE(MIN(experience_first_published_at)) experience_first_published_at
-    FROM (
-      SELECT
-        *,
-        MIN(iteration_published_at) OVER (PARTITION BY experienceId) AS experience_first_published_at,
-        CAST(DATE(iteration_paused_at) AS STRING) iteration_paused_at_date,
-        CAST(DATE(iteration_published_at) AS STRING) iteration_published_at_date,
-        UNIX_MILLIS(iteration_paused_at) AS iteration_paused_at_unix_ts,
-        MAX(iteration_paused_at) OVER (PARTITION BY experienceId) AS experience_last_paused_at
-      FROM (
+      WITH
+      iterations AS
+      (
         SELECT
-          COALESCE(iteration_published_at_first,iteration_started_at,iteration_created_at,iteration_upadted_at) AS iteration_published_at,
-          *
+          experienceId AS experienceId,
+          variationMasterId AS variationMasterId,
+          iterationId AS iterationId,
+          MAX(iterationName) AS iterationName,
+          MIN(iterationStartedAt) AS iterationStartedAt,
+          MIN(iterationPublishedAt) AS iterationPublishedAt,
+          MIN(iterationPausedAt) AS iterationPausedAt
+        FROM
+          `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.aux_experience_iteration_variation_v01`
+        WHERE
+          experienceId IS NOT NULL
+          AND iterationId IS NOT NULL
+          AND variationMasterId IS NOT NULL
+        GROUP BY
+          1,
+          2,
+          3 ),
+
+        iteration_metadata AS
+        (
+        SELECT
+          experienceId,
+          variationMasterId,
+          iterationId,
+          iterationName,
+          iterationStartedAt,
+          iterationPausedAt,
+          IF (iterationPublishedAt IS NULL,
+            TRUE,
+            FALSE) AS inDraft,
+          IF (iterationId = FIRST_VALUE(iterationId) OVER (PARTITION BY experienceId, variationMasterId ORDER BY iterationStartedAt DESC),
+            TRUE,
+            FALSE) AS isLatestIteration
+        FROM
+          iterations
+      ),
+
+      status AS
+      (
+        SELECT
+          *,
+          IF (isLatestIteration = TRUE
+            AND iterationPausedAt IS NULL
+            AND iterationStartedAt IS NOT NULL,
+            TRUE,
+            FALSE) AS isActive
+        FROM
+          iteration_metadata
+      ),
+
+      latestName AS (
+        SELECT
+          ROW.experienceId,
+          ROW.experienceName
         FROM (
           SELECT
-            experienceId AS experienceId,
-            variationMasterId AS variationMasterId,
-            iterationId AS iterationId,
-            MAX(experienceName) AS experienceName,
-            MAX(variationName) AS variationName,
-            MAX(iterationName) AS iterationName,
-            MIN(CASE
-                  WHEN iterationUpdatedAt > COALESCE(iterationStartedAt, TIMESTAMP_MILLIS(0)) AND iterationPausedAt IS NULL THEN iterationUpdatedAt
-                  WHEN iterationPausedAt > COALESCE(iterationStartedAt, TIMESTAMP_MILLIS(0))
-                AND iterationPausedAt > COALESCE(iterationPublishedAt, TIMESTAMP_MILLIS(0))
-                AND iterationPausedAt > COALESCE(iterationResumedAt, TIMESTAMP_MILLIS(0)) THEN iterationPausedAt
-                  ELSE TIMESTAMP('2030-01-01 00:00:00 UTC') END) AS iteration_paused_at,
-            MIN(iterationPublishedAt) AS iteration_published_at_first,
-            MIN(iterationStartedAt) AS iteration_started_at,
-            MIN(iterationCreatedAt) AS iteration_created_at,
-            MIN(iterationUpdatedAt) AS iteration_upadted_at
+            ARRAY_AGG(t
+            ORDER BY
+              meta_recordDate DESC
+            LIMIT
+              1)[
+          OFFSET
+            (0)] AS ROW
           FROM
-            `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.aux_experience_iteration_variation_v01`
+            `qubit-client-{{q_view_v01.project._parameter_value}}.{{q_view_v01.site._parameter_value}}__v2.aux_experience_iteration_variation_v01` AS t
           GROUP BY
-            1,
-            2,
-            3) AS experience_metadata ) AS experience_metadata_1
-      WHERE
-        (experienceId IS NOT NULL
-          AND CAST(experienceId AS STRING) != 'undefined'
-          AND variationMasterId IS NOT NULL
-          AND CAST(variationMasterId AS STRING) != 'undefined'
-          AND iterationId IS NOT NULL
-          AND CAST(iterationId AS STRING) != 'undefined' ))
+            experienceId,
+            experienceName
+        )
+    )
+
+    SELECT
+      CAST(status.experienceId AS STRING) experienceId,
+      CAST(experienceName as STRING) experienceName,
+      DATE(MIN(iterationStartedAt)) experience_first_published_at,
+      DATE(MAX(iterationPausedAt)) experience_last_paused_at,
+      MAX(isActive) AS is_active
+
+    FROM
+      status
+
+    LEFT JOIN
+      latestName on (status.experienceId = latestName.experienceId)
+
+
     GROUP BY
-      1
-    ;;}
+      1, 2
+    ;;
+  }
 
   dimension: experience_id {
     type: string
@@ -62,15 +105,18 @@ view: q_goal_achieved_meta_data {
   dimension: experience_name {
     type: string
     sql: ${TABLE}.experienceName ;;
-    hidden: yes
+    view_label: "Goal Achieved"
+    group_label: "Experience"
+    label: "Experience Name"
+    description: "The name of experience in app.qubit.com."
   }
 
   dimension: g_current_experience_status {
     view_label: "Goal Achieved"
     type: string
-    sql: IF(${TABLE}.experience_last_paused_at <= CURRENT_DATE() , "Paused" , "Active") ;;
+    sql: IF(${TABLE}.is_active = true , "Active" , "Paused") ;;
     label: "Current Experience Status "
-    description: "Status of the experience as of today"
+    description: "Status of the experience as of today."
     group_label: "Experience"
   }
 
@@ -79,7 +125,7 @@ view: q_goal_achieved_meta_data {
     type: date
     sql: TIMESTAMP(${TABLE}.experience_first_published_at) ;;
     group_label: "Experience"
-    description: "Date the first iteration of experience was published"
+    description: "Date the first iteration of experience was published."
     label: "Experience First Published At"
   }
 
@@ -88,7 +134,7 @@ view: q_goal_achieved_meta_data {
     type: date
     sql: TIMESTAMP(${TABLE}.experience_last_paused_at) ;;
     group_label: "Experience"
-    description: "Most recent date experience was paused"
+    description: "Most recent date experience was paused."
     label: "Experience Last Paused At"
-    }
+  }
 }


### PR DESCRIPTION
- Updated `q_experience`* and `q_goal_achieved`* views to provide latest _Experience Name_.
- Updated `q_experience`* and `q_goal_achieved`* views to fix a rare issue where _Experience Status_ was calculated incorrectly.
- Fixed column type bug that was preventing `q_goal_achieved.days_experience_live` from calculating.