### PR TITLE
June 2019 - v2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Qubit is the fastest and most scalable personalization platform available today.
 
 # Release notes
 
+**June 2019 - Release v2.6**
+- Updated `q_transaction` to ensure that measures `average_order_value`, `revenue_per_converter`, `revenue_per_visitor` are always calculated using sum_distinct.
+
 **March 2019 - Release v2.5**
 - Updated `q_experience`* and `q_goal_achieved`* views to provide latest _Experience Name_
 - Updated `q_experience`* and `q_goal_achieved`* views to fix a rare issue where _Experience Status_ was calculated incorrectly

--- a/q_transaction.view.lkml
+++ b/q_transaction.view.lkml
@@ -156,14 +156,14 @@ view: q_transaction {
 
   measure: average_order_value {
     type: number
-    sql:  SAFE_DIVIDE(SUM(${TABLE}.basket_total_baseValue), COUNT(DISTINCT ${transaction_id})) ;;
+    sql:  SAFE_DIVIDE(${q_transaction_v01.sum_of_transaction_total}, COUNT(DISTINCT ${transaction_id})) ;;
     value_format_name: decimal_2
     description: "Average of transaction value of all transactions. QP fields: basket_total_baseValue"
   }
 
   measure: revenue_per_converter {
     type: number
-    sql:  SAFE_DIVIDE(SUM(${TABLE}.basket_total_baseValue), COUNT(DISTINCT ${TABLE}.context_id)) ;;
+    sql:  SAFE_DIVIDE(${q_transaction_v01.sum_of_transaction_total}, COUNT(DISTINCT ${TABLE}.context_id)) ;;
     value_format_name: decimal_2
     description: "Sum of transaction_total divided by count of unique visitor_ids. Only for views that are labeled with any non-null transaction_id. QP fields: basket_total_baseValue, context_id"
   }
@@ -212,7 +212,7 @@ view: q_transaction {
 
   measure: revenue_per_visitor {
     type: number
-    sql: ${q_transaction_v01.sum_of_transaction_total} / ${q_view_v01.view_visitors} ;;
+    sql: SAFE_DIVIDE(${q_transaction_v01.sum_of_transaction_total}, ${q_view_v01.view_visitors}) ;;
     value_format_name: decimal_2
     description: "Sum of transaction_total divided by count of unique visitor_ids. QP fields: basket_total_baseValue, context_id"
   }


### PR DESCRIPTION
**June 2019 - Release v2.6**
- Updated `q_transaction` to ensure that measures `average_order_value`, `revenue_per_converter`, `revenue_per_visitor` are always calculated using sum_distinct.